### PR TITLE
Dev

### DIFF
--- a/Awaitable/Awaitable.h
+++ b/Awaitable/Awaitable.h
@@ -620,22 +620,22 @@ namespace pi
 
         // NB: use of template template parameter is to avoid recursive template instantiation when retrieving the proxy type!
         //template < template <typename> class _awaitable > // TODO: try without template template parameter
-        static nawaitable await_one(awaitable<awaitable> aa, awaitable<awaitable> r, cancellation::token ct = cancellation::token::none())
-        {
-            // NB: the cancellation token will remain in scope until the current function returns
-            ct.register_action([&aa] { aa.set_exception(std::make_exception_ptr(std::exception("await_one.cancellation"))); });
+        //static nawaitable await_one(awaitable<awaitable> aa, awaitable<awaitable> r, cancellation::token ct = cancellation::token::none())
+        //{
+        //    // NB: the cancellation token will remain in scope until the current function returns
+        //    ct.register_action([&aa] { aa.set_exception(std::make_exception_ptr(std::exception("await_one.cancellation"))); });
 
-            try
-            {
-                co_await aa;
-                r.set_ready(aa.get_value());
-            }
-            catch (...)
-            {
-                r.set_exception(std::current_exception());
-                return;
-            }
-        }
+        //    try
+        //    {
+        //        co_await aa;
+        //        r.set_ready(aa.get_value());
+        //    }
+        //    catch (...)
+        //    {
+        //        r.set_exception(std::current_exception());
+        //        return;
+        //    }
+        //}
 
         static nawaitable await_one(awaitable a, awaitable<void> r, size_t& count = 0, cancellation::token ct = cancellation::token::none())
         {

--- a/Awaitable/Awaitable.h
+++ b/Awaitable/Awaitable.h
@@ -691,10 +691,9 @@ namespace pi
         // [2-1]
         friend awaitable<awaitable> operator||(awaitable<awaitable> a1, awaitable a2)
         {
-            awaitable<awaitable> r{ true };
-            await_one(a1, r);
-            await_one(a2, r);
-            return r;
+            // NB: instead of creating another awaitable<awaitable>, we just reuse a1! 
+            await_one(a2, a1);
+            return a1;
         }
 
         // [2-2]


### PR DESCRIPTION
operator|| now will only create as many raw await_one coroutines as there are number of raw operands, no exponential creation of extra await_one coroutines, also much simpler logic